### PR TITLE
Static physics material resource

### DIFF
--- a/gameplay_cpp/src/character/playerNode.cpp
+++ b/gameplay_cpp/src/character/playerNode.cpp
@@ -5,12 +5,12 @@
 #include <character/gui/playerGui.hpp>
 
 #include <managers/inputManager.h>
-#include <components/weapon.hpp>
 #include <components/animation.hpp>
 #include <components/attackInstigator.hpp>
 #include <components/grappleInstigator.hpp>
 #include <components/grappleTarget.hpp>
 #include <components/parryInstigator.hpp>
+#include <components/weapon.hpp>
 
 #include "../utils/circularbuffer.h"
 #include "fsm/typedefs.hpp"
@@ -21,7 +21,6 @@
 #include <godot_cpp/classes/input.hpp>
 #include <godot_cpp/classes/input_event_action.hpp>
 #include <godot_cpp/classes/input_event_joypad_motion.hpp>
-#include <godot_cpp/classes/physics_material.hpp>
 #include <godot_cpp/classes/progress_bar.hpp>
 #include <godot_cpp/classes/sphere_shape3d.hpp>
 #include <godot_cpp/classes/viewport.hpp>
@@ -61,11 +60,6 @@ void PlayerNode::_enter_tree() {
 	set_contact_monitor(true); // Required for _integrate_forces()
 	set_max_contacts_reported(4);
 	set_can_sleep(false); // _integrate_forces is not invoked once body is sleeping
-	{ // Each state needs to handle the physics material, so we override it here
-		Ref<PhysicsMaterial> mat;
-		mat.instantiate();
-		set_physics_material_override(mat);
-	}
 
 	RETURN_IF_EDITOR(void())
 
@@ -95,6 +89,9 @@ void PlayerNode::_enter_tree() {
 	ASSERTNN(audio)
 	ASSERTNN(particles)
 	ASSERTNN(gui)
+	ASSERT(get_physics_material_override().is_valid(),
+		"PlayerNode is expected to have its physics material overriden") // Each state needs to handle the physics
+																		 // material
 
 	stateContext.owner = this;
 	stateContext.weapon = m_weaponComponent;

--- a/libraries/core/assert.hpp
+++ b/libraries/core/assert.hpp
@@ -7,8 +7,7 @@ inline void __m_assert(const char* expr_str, bool expr, const char* file, int li
 	if (!expr) {
 		std::cerr << "Assert failed:\t" << msg << "\n"
 				  << "Expected:\t" << expr_str << "\n"
-				  << "Source:\n"
-				  << file << "\nline " << line << "\n";
+				  << "Source:\t\t" << file << ":" << line << "\n";
 		abort();
 	}
 }

--- a/libraries/core/godotUtils.hpp
+++ b/libraries/core/godotUtils.hpp
@@ -158,6 +158,10 @@ public:                                                                         
 #define S_STRING_IMPL(variableName, functionName, ...) _S_IMPL(variableName, functionName, godot::String, __VA_ARGS__)
 #define GS_STRING_IMPL(variableName, functionName, ...) _GS_IMPL(variableName, functionName, godot::String, __VA_ARGS__)
 
+#define G_RESOURCE_IMPL(variableName , resourceType, functionName, ...) static_assert(std::is_base_of_v<godot::Resource, resourceType>); _G_IMPL(variableName, functionName,   godot::Ref<resourceType>, __VA_ARGS__)
+#define S_RESOURCE_IMPL(variableName , resourceType, functionName, ...) static_assert(std::is_base_of_v<godot::Resource, resourceType>); _S_IMPL(variableName, functionName,   godot::Ref<resourceType>, __VA_ARGS__)
+#define GS_RESOURCE_IMPL(variableName, resourceType, functionName, ...) static_assert(std::is_base_of_v<godot::Resource, resourceType>); _GS_IMPL(variableName, functionName,  godot::Ref<resourceType>, __VA_ARGS__)
+
 #define G_VECTOR2I_IMPL(variableName, functionName, ...)                                                               \
 	_G_IMPL(variableName, functionName, godot::Vector2i, __VA_ARGS__)
 #define S_VECTOR2I_IMPL(variableName, functionName, ...)                                                               \

--- a/project/assetscenes/player.tscn
+++ b/project/assetscenes/player.tscn
@@ -10,10 +10,7 @@
 [ext_resource type="Curve" uid="uid://heoulagsihcy" path="res://curve/attackAnimationCurve.tres" id="6_wu6nb"]
 [ext_resource type="Script" path="res://addons/GPUTrail/GPUTrail3D.gd" id="7_iov6s"]
 
-[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_hjgm0"]
-
-[sub_resource type="BoxShape3D" id="BoxShape3D_5oxfn"]
-size = Vector3(2.08374, 1.7627, 0.460938)
+[sub_resource type="PhysicsMaterial" id="PhysicsMaterial_l8sdf"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_xmldd"]
 radius = 0.279674
@@ -333,7 +330,7 @@ radius = 1.521
 [node name="PlayerNode" type="PlayerNode"]
 collision_layer = 6
 collision_mask = 3
-physics_material_override = SubResource("PhysicsMaterial_hjgm0")
+physics_material_override = SubResource("PhysicsMaterial_l8sdf")
 gravity_scale = 0.0
 can_sleep = false
 lock_rotation = true
@@ -357,7 +354,7 @@ transform = Transform3D(0.394366, 0.0641302, 0.574772, 0.522334, 0.259158, -0.38
 bone_name = "mixamorig_RightHand"
 bone_idx = 34
 use_external_skeleton = true
-external_skeleton = NodePath("../meshAnchor/character/Armature/Skeleton3D")
+external_skeleton = NodePath("/root/@EditorNode@17149/@Panel@13/@VBoxContainer@14/@HSplitContainer@17/@HSplitContainer@25/@HSplitContainer@33/@VBoxContainer@34/@VSplitContainer@36/@VSplitContainer@62/@VBoxContainer@63/@PanelContainer@110/MainScreen/@CanvasItemEditor@9462/@VSplitContainer@9281/@HSplitContainer@9283/@HSplitContainer@9285/@Control@9286/@SubViewportContainer@9287/@SubViewport@9288/PlayerNode/meshAnchor/character/Armature/Skeleton3D")
 
 [node name="scissors_vintage" parent="ComponentWeapon" instance=ExtResource("2_6ra04")]
 transform = Transform3D(0.292819, 0.158548, 0.727406, 0.713494, 0.163412, -0.322836, -0.212565, 0.766915, -0.0815917, 0.00493367, 0.457184, -0.0350523)
@@ -475,6 +472,7 @@ shape = SubResource("SphereShape3D_en38a")
 [node name="ComponentGrappleInstigator" type="ComponentGrappleInstigator" parent="."]
 ColliderPath = NodePath("../GrappleDetection")
 PullStrength = nan
+Mass = 1.4013e-45
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.00901, 0)
 
 [node name="PlayerGui" parent="." instance=ExtResource("3_32mh5")]


### PR DESCRIPTION
PlayerNode regenerates a custom physics material on _enter_tree, generating a new hash and git marks it as a change. 

Its annoying

Also setting precedence on how to handle custom resources from code. 